### PR TITLE
crc32: Fix htole32 issue

### DIFF
--- a/crc32.c
+++ b/crc32.c
@@ -12,7 +12,11 @@
 #include <endian.h>
 #include <sys/types.h>
 
-#define tole(x) htole32(x)
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+#define tole(x) (x)
+#else
+#define tole(x) __bswap_constant_32(x)
+#endif
 
 #ifdef DYNAMIC_CRC_TABLE
 


### PR DESCRIPTION
While compiling fwupgrade, it fails with the error:

crc32.c:15:17: error: initializer element is not constant
 #define tole(x) htole32(x)

To solve this, set the code to return directly the variable
when in little endian mode and __bswap_constant_32 on big endian

Signed-off-by: Mylène Josserand <mylene.josserand@bootlin.com>